### PR TITLE
Updated dependency & improved Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Please cite [JuFiT: A Configurable Rule Engine for Filtering and Generating New 
 
 ## Usage
 ```
+java -jar <JUFIT-JAR> 
+```
+followed by
+```
  jufit <mrconso> <mrsty> <language> (--mrconso | --terms | --grounded | --complex) [--outFile=FILE] [--semanticGroup=GROUP]... [--rules=JSON] [--noFilter]
  jufit --help
  jufit --version

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please cite [JuFiT: A Configurable Rule Engine for Filtering and Generating New 
 ```
 java -jar <JUFIT-JAR> 
 ```
-followed by
+followed by (on the same line)
 ```
  jufit <mrconso> <mrsty> <language> (--mrconso | --terms | --grounded | --complex) [--outFile=FILE] [--semanticGroup=GROUP]... [--rules=JSON] [--noFilter]
  jufit --help

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>de.julielab</groupId>
 		<artifactId>julielab-parent</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.4.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Hey @chlor I tried to address the two problems we talked about:
- The build failed for me due to an old snapshot dependency, I switched to the latest version of julielab-parent I could find
- My prior changes to the readme left out the need to use java -jar

The build worked for me with Amazon's java/javac 11.0.3 and maven 3.6.0